### PR TITLE
Fix crash if Vorbis stream is corrupted.

### DIFF
--- a/source/base/StarMixer.cpp
+++ b/source/base/StarMixer.cpp
@@ -309,49 +309,57 @@ void Mixer::read(int16_t* outBuffer, size_t frameCount, ExtraMixFunction extraMi
           m_mixBuffer[i] = 0;
         ramt += silentSamples * channels;
       }
-      ramt += audioInstance->m_audio.resample(channels, sampleRate, m_mixBuffer.ptr() + ramt, bufferSize - ramt, pitchMultiplier);
-      while (ramt != bufferSize && !finished) {
-        // Only seek back to the beginning and read more data if loops is < 0
-        // (loop forever), or we have more loops to go, otherwise, the sample is
-        // finished.
-        if (audioInstance->m_loops != 0) {
-          audioInstance->m_audio.seekSample(0);
-          ramt += audioInstance->m_audio.resample(channels, sampleRate, m_mixBuffer.ptr() + ramt, bufferSize - ramt, pitchMultiplier);
-          if (audioInstance->m_loops > 0)
-            --audioInstance->m_loops;
-        } else {
-          finished = true;
-        }
-      }
-      if (audioInstance->m_clockStop && *audioInstance->m_clockStop < sampleEndTime) {
-        for (size_t s = 0; s < ramt / channels; ++s) {
-          unsigned millisecondsInBuffer = (s * 1000) / sampleRate;
-          auto sampleTime = sampleStartTime + millisecondsInBuffer;
-          if (sampleTime > *audioInstance->m_clockStop) {
-            float volume = 0.0f;
-            if (audioInstance->m_clockStopFadeOut > 0)
-              volume = 1.0f - (float)(sampleTime - *audioInstance->m_clockStop) / (float)audioInstance->m_clockStopFadeOut;
 
-            if (volume <= 0) {
-              for (size_t c = 0; c < channels; ++c)
-                m_mixBuffer[s * channels + c] = 0;
-            } else {
-              for (size_t c = 0; c < channels; ++c)
-                m_mixBuffer[s * channels + c] *= volume;
-            }
+      try {
+        ramt += audioInstance->m_audio.resample(channels, sampleRate, m_mixBuffer.ptr() + ramt, bufferSize - ramt, pitchMultiplier);
+        while (ramt != bufferSize && !finished) {
+          // Only seek back to the beginning and read more data if loops is < 0
+          // (loop forever), or we have more loops to go, otherwise, the sample is
+          // finished.
+          if (audioInstance->m_loops != 0) {
+            audioInstance->m_audio.seekSample(0);
+            ramt += audioInstance->m_audio.resample(channels, sampleRate, m_mixBuffer.ptr() + ramt, bufferSize - ramt, pitchMultiplier);
+            if (audioInstance->m_loops > 0)
+              --audioInstance->m_loops;
+          } else {
+            finished = true;
           }
         }
-        if (sampleEndTime > *audioInstance->m_clockStop + audioInstance->m_clockStopFadeOut)
-          finished = true;
-      }
 
-      for (size_t s = 0; s < ramt / channels; ++s) {
-        float vol = lerp((float)s / frameCount, beginVolume * groupVolume * audioStopVolBegin, endVolume * groupEndVolume * audioStopVolEnd);
-        for (size_t c = 0; c < channels; ++c) {
-          float sample = m_mixBuffer[s * channels + c] * vol * audioState.positionalChannelVolumes[c] * audioInstance->m_volume.value;
-          int16_t& outSample = outBuffer[s * channels + c];
-          outSample = clamp(sample + outSample, -32767.0f, 32767.0f);
+        if (audioInstance->m_clockStop && *audioInstance->m_clockStop < sampleEndTime) {
+          for (size_t s = 0; s < ramt / channels; ++s) {
+            unsigned millisecondsInBuffer = (s * 1000) / sampleRate;
+            auto sampleTime = sampleStartTime + millisecondsInBuffer;
+            if (sampleTime > *audioInstance->m_clockStop) {
+              float volume = 0.0f;
+              if (audioInstance->m_clockStopFadeOut > 0)
+                volume = 1.0f - (float)(sampleTime - *audioInstance->m_clockStop) / (float)audioInstance->m_clockStopFadeOut;
+
+              if (volume <= 0) {
+                for (size_t c = 0; c < channels; ++c)
+                  m_mixBuffer[s * channels + c] = 0;
+              } else {
+                for (size_t c = 0; c < channels; ++c)
+                  m_mixBuffer[s * channels + c] *= volume;
+              }
+            }
+          }
+          if (sampleEndTime > *audioInstance->m_clockStop + audioInstance->m_clockStopFadeOut)
+            finished = true;
         }
+
+        for (size_t s = 0; s < ramt / channels; ++s) {
+          float vol = lerp((float)s / frameCount, beginVolume * groupVolume * audioStopVolBegin, endVolume * groupEndVolume * audioStopVolEnd);
+          for (size_t c = 0; c < channels; ++c) {
+            float sample = m_mixBuffer[s * channels + c] * vol * audioState.positionalChannelVolumes[c] * audioInstance->m_volume.value;
+            int16_t& outSample = outBuffer[s * channels + c];
+            outSample = clamp(sample + outSample, -32767.0f, 32767.0f);
+          }
+        }
+
+      } catch (Star::AudioException& ex) {
+        Logger::error("Audio: Error reading audio data: {}", ex.what());
+        finished = true;
       }
 
       audioInstance->m_volume.value = audioStopVolEnd;

--- a/source/core/StarAudio.cpp
+++ b/source/core/StarAudio.cpp
@@ -219,15 +219,19 @@ public:
 
   size_t readPartial(int16_t* buffer, size_t bufferSize) {
     int bitstream;
-    int read;
+    int read = OV_HOLE;
     // ov_read takes int parameter, so do some magic here to make sure we don't
     // overflow
     bufferSize *= 2;
+
+    // Just silently skip over data holes.
+    while (read == OV_HOLE) {
 #if STAR_LITTLE_ENDIAN
-    read = ov_read(&m_vorbisFile, (char*)buffer, bufferSize, 0, 2, 1, &bitstream);
+      read = ov_read(&m_vorbisFile, (char*)buffer, bufferSize, 0, 2, 1, &bitstream);
 #else
-    read = ov_read(&m_vorbisFile, (char*)buffer, bufferSize, 1, 2, 1, &bitstream);
+      read = ov_read(&m_vorbisFile, (char*)buffer, bufferSize, 1, 2, 1, &bitstream);
 #endif
+    }
     if (read < 0)
       throw AudioException("Error in Audio::read");
 


### PR DESCRIPTION
Crashed due to an unhandled exception in SDL2's audio callback if a Vorbis data stream had errors in it. We now silently skip over holes in the stream, and log other errors without crashing, just returning zero bytes read instead which is already handled appropriately.