### PR TITLE
Fix the Wayland test in xclient.sh

### DIFF
--- a/scripts/linux/xclient.sh
+++ b/scripts/linux/xclient.sh
@@ -4,7 +4,7 @@ sbPath="$(realpath -zL $0 | xargs -0 dirname)/../"; export sbPath;
 cd "`dirname \"$0\"`";
 
 # automatically switch to wayland support if it seems like it's running
-if [ -z "$WAYLAND_DISPLAY" ]; then 
+if [ -n "$WAYLAND_DISPLAY" ]; then 
   export SDL_VIDEODRIVER="wayland"
 fi
 


### PR DESCRIPTION
The -z test checks whether the string has a length of zero, in other words we were checking whether WAYLAND_DISPLAY was unset. With -n we check whether it's IS set.